### PR TITLE
add missing `end`

### DIFF
--- a/src/graph_sampler.jl
+++ b/src/graph_sampler.jl
@@ -332,33 +332,34 @@ function config_model(clusters, params)
     if isempty(recycle)
         @assert 2 * length(global_edges) == length(stubs)
     else
-    last_recycle = length(recycle)
-    recycle_counter = last_recycle
-    while !isempty(recycle)
-        recycle_counter -= 1
-        if recycle_counter < 0
-            if length(recycle) < last_recycle
-                last_recycle = length(recycle)
-                recycle_counter = last_recycle
-            else
-                break
+        last_recycle = length(recycle)
+        recycle_counter = last_recycle
+        while !isempty(recycle)
+            recycle_counter -= 1
+            if recycle_counter < 0
+                if length(recycle) < last_recycle
+                    last_recycle = length(recycle)
+                    recycle_counter = last_recycle
+                else
+                    break
+                end
             end
-        end
-        p1 = pop!(recycle)
-        x = rand(edges)
-        p2 = pop!(edges, x)
-        if rand() < 0.5
-            newp1 = minmax(p1[1], p2[1])
-            newp2 = minmax(p1[2], p2[2])
-        else
-            newp1 = minmax(p1[1], p2[2])
-            newp2 = minmax(p1[2], p2[1])
-        end
-        for newp in (newp1, newp2)
-            if (newp[1] == newp[2]) || (newp in edges)
-                push!(recycle, newp)
+            p1 = pop!(recycle)
+            x = rand(edges)
+            p2 = pop!(edges, x)
+            if rand() < 0.5
+                newp1 = minmax(p1[1], p2[1])
+                newp2 = minmax(p1[2], p2[2])
             else
-                push!(edges, newp)
+                newp1 = minmax(p1[1], p2[2])
+                newp2 = minmax(p1[2], p2[1])
+            end
+            for newp in (newp1, newp2)
+                if (newp[1] == newp[2]) || (newp in edges)
+                    push!(recycle, newp)
+                else
+                    push!(edges, newp)
+                end
             end
         end
     end


### PR DESCRIPTION
fix for
```julia
julia> using ABCDGraphGenerator
[ Info: Precompiling ABCDGraphGenerator [4c9194b5-d5d9-4bea-bd96-43ca8ce89b0b]
ERROR: LoadError: LoadError: syntax: incomplete: "function" at ABCDGraphGenerator.jl/src/graph_sampler.jl:140 requires end
Stacktrace:
  [1] top-level scope
    @ ABCDGraphGenerator.jl/src/graph_sampler.jl:140
  [2] include(mod::Module, _path::String)
    @ Base ./Base.jl:386
  [3] include(x::String)
    @ ABCDGraphGenerator ABCDGraphGenerator.jl/src/ABCDGraphGenerator.jl:1
  [4] top-level scope
    @ ABCDGraphGenerator.jl/src/ABCDGraphGenerator.jl:7
  [5] include
    @ ./Base.jl:386 [inlined]
  [6] include_package_for_output(pkg::Base.PkgId, input::String, depot_path::Vector{String}, dl_load_path::Vector{String}, load_path::Vector{String}, concrete_deps::Vector{Pair{Base.PkgId, UInt64}}, source::Nothing)
    @ Base ./loading.jl:1235
  [7] top-level scope
    @ none:1
  [8] eval
    @ ./boot.jl:360 [inlined]
  [9] eval(x::Expr)
    @ Base.MainInclude ./client.jl:446
 [10] top-level scope
    @ none:1
in expression starting at ABCDGraphGenerator.jl/src/graph_sampler.jl:140
in expression starting at ABCDGraphGenerator.jl/src/ABCDGraphGenerator.jl:1
```