### PR TITLE
change julia base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM julia:1.7.3-alpine
+FROM julia:1.7.3
 
 WORKDIR /app
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: run
 run:
-	docker-compose run --rm app ash
+	docker-compose run --rm app bash
 
 .PHONY: save
 save:


### PR DESCRIPTION
This commit updates base julia image from alpine-based to Ubuntu based.

alpine is a lightweight Linux OS, which makes a docker image smaller in size (which, in turn, is a good practice). 
Nevertheless, alpine OS is not compatible with macOS, and if the goal is to ensure ability to replicate accross different OSes, the following changes are needed (even at the cost of making Docker image slightly heavier in size).